### PR TITLE
review1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ MANDATORY_CFLAGS := -fno-strict-aliasing -Werror=format \
 						  -pedantic-errors
 TARGET = '$(subst ','\'',$@)'#
 SOURCE = '$(subst ','\'',$<)'#
+# marmarek: detect based on $(CC) ?
 ifeq "$(WARNINGS)" "clang"
 EXTRA_CFLAGS := -fsanitize=undefined -fsanitize-minimal-runtime  \
 	-fPIC -Weverything -Wno-c++98-compat \

--- a/main.c
+++ b/main.c
@@ -12,6 +12,7 @@ int main(int argc, char **argv)
       abort();
    if (argc < 2) {
       LOG("Bad number of arguments: expected at least 1 but got %d", argc - 1);
+      // marmarek: add usage info, like what that "at least 1" arg should be
       return EXIT_FAILURE;
    }
    for (int i = 1; i < argc; ++i) {
@@ -27,6 +28,7 @@ int main(int argc, char **argv)
       uint8_t *fbuf = malloc(size);
       if (!fbuf)
          err(1, "malloc(%zu)", size);
+      // marmarek: mmap instead of read? but also, if keeping read(), you probably need to handle short read, not error out on it
       if ((size_t)read(p, fbuf, size) != size)
          err(1, "read()");
       struct ParsedImage image;

--- a/test.c
+++ b/test.c
@@ -18,6 +18,7 @@ static void test_dos_header(void) {
    assert(extract_pe_header(header, 0x7FFFFFFFUL + 1) == NULL);
    // Corrupt the NT header magic
    uint32_t nt_offset = 128;
+   // marmarek: what is 60? use #define or a comment (or sizeof() relevant structure) to describe it
    memcpy(header + 60, &nt_offset, 4);
    memcpy(header + nt_offset, "PE\0", 4);
    header[0] = 'M';


### PR DESCRIPTION
Most comments added inline.

I tried it also on our [current UKI](https://gitlab.com/QubesOS/qubes-vmm-xen-unified/-/jobs/8829912966/artifacts/file/artifacts/repository/host-fc41/vmm-xen-unified_4.19.1r2+6.12.5r2/qubes-vmm-xen-unified-4.19.1r2+6.12.5r2-1.1.fc41.x86_64.rpm):
```
$ ./winpe qubes-vmm-xen-unified-4.19.1r2+6.12.5r2-1.1.fc41.x86_64/boot/uki-xen-signed-4.19.1r2+6.12.5r2-1.1.fc41.efi
COFF symbol tables detected: symbol table offset 0x4f9a960, number of symbols 0x1f9d
This is a PE32+ file: magic 0x20b
Section 0(name .text) has flags 0xe0000020
Section 1(name .rodata) has flags 0xc0000040
Section 2 (.buildid) has misaligned VMA: 0xffff82d04043f6a0 not aligned to 0x200000
Section 2(name .buildid) has flags 0x40000040
Section 3(name .init) has flags 0xe0000060
Section 4(name .data.re) has flags 0xc0000040
Section 5 (.data) has misaligned VMA: 0xffff82d04080b000 not aligned to 0x200000
Section 5(name .data) has flags 0xc0000040
Section 6 (.bss) has misaligned VMA: 0xffff82d040818000 not aligned to 0x200000
Section 6(name .bss) has flags 0xc0000080
Section 7 (.reloc) has misaligned VMA: 0xffff82d04098bb20 not aligned to 0x200000
Section 7(name .reloc) has flags 0x42000040
Section 8 (.debug_a) has misaligned VMA: 0xffff82d04098d13c not aligned to 0x200000
Section 8(name .debug_a) has flags 0x42000040
Section 9 (.debug_i) has misaligned VMA: 0xffff82d040a2f98d not aligned to 0x200000
Section 9(name .debug_i) has flags 0x42000040
Section 10 (.debug_s) has misaligned VMA: 0xffff82d0416ea701 not aligned to 0x200000
Section 10(name .debug_s) has flags 0x42000040
Section 11 (.debug_l) has misaligned VMA: 0xffff82d041c96007 not aligned to 0x200000
Section 11(name .debug_l) has flags 0x42000040
Section 12 (.debug_l) has misaligned VMA: 0xffff82d041eb8d7e not aligned to 0x200000
Section 12(name .debug_l) has flags 0x42000040
Section 13 (.debug_f) has misaligned VMA: 0xffff82d041f09e00 not aligned to 0x200000
Section 13(name .debug_f) has flags 0x42000040
Section 14 (.debug_l) has misaligned VMA: 0xffff82d041f4dba0 not aligned to 0x200000
Section 14(name .debug_l) has flags 0x42000040
Section 15 (.debug_r) has misaligned VMA: 0xffff82d0421cf3c8 not aligned to 0x200000
Section 15(name .debug_r) has flags 0x42000040
Section 16 (.debug_a) has misaligned VMA: 0xffff82d0422427c0 not aligned to 0x200000
Section 16(name .debug_a) has flags 0x42000040
Section 17(name .config) has flags 0x40000040
Section 18(name .kernel) has flags 0x40000040
Section 19(name .ramdisk) has flags 0x40000040
Signature at offset 0x4fddca0 with length 0x8b0
```
It exits with 0, but there is quite a few messages. It would be helpful to make messages more clear whether it is some issue (that should be for example fixed in our UKI), or is it only informative.