### PR TITLE
Cleanup code, support long section names, and disable certain checks by default

### DIFF
--- a/main.c
+++ b/main.c
@@ -17,10 +17,16 @@ int main(int argc, char **argv)
    struct option opts[] = {
        { "verbose", no_argument, NULL, 'v' },
        { "no-verbose", no_argument, NULL, 'V' },
+       { "strict", no_argument, NULL, 's' },
+       { "no-strict", no_argument, NULL, 'S' },
+       { "require-relocs", no_argument, NULL, 'r' },
+       { "no-require-relocs", no_argument, NULL, 'R' },
        { "help", no_argument, NULL, 'h' },
        { NULL, 0, NULL, 0 },
    };
    bool verbose = false;
+   bool strict = false;
+   bool require_relocs = false;
    for (;;) {
       int index;
       int v = getopt_long(argc, argv, "+", opts, &index);
@@ -28,14 +34,26 @@ int main(int argc, char **argv)
          case ':':
          case '?':
             return EXIT_FAILURE;
+         case 's':
+            strict = true;
+            break;
+         case 'S':
+            strict = false;
+            break;
          case 'v':
             verbose = true;
             break;
          case 'V':
             verbose = false;
             break;
+         case 'R':
+            require_relocs = false;
+            break;
+         case 'r':
+            require_relocs = true;
+            break;
          case 'h':
-            fputs("Usage: pechk [--verbose] [--no-verbose] [--] FILE [FILES...]\n", stdout);
+            fputs("Usage: pecheck [--strict] [--no-strict] [--verbose] [--no-verbose] [--] FILE [FILES...]\n", stdout);
             if (fflush(NULL) || ferror(stdout))
                errx(1, "I/O error on stdout");
             return 0;
@@ -71,7 +89,7 @@ end_of_options:
           data_read += (size_t)bytes_read;
       }
       struct ParsedImage image;
-      if (!pe_parse(fbuf, size, &image, verbose))
+      if (!pe_parse(fbuf, size, &image, verbose, strict, require_relocs))
          errx(1, "bad PE file");
       if (fflush(NULL) || ferror(stdout) || ferror(stderr))
          errx(1, "I/O error");

--- a/test.c
+++ b/test.c
@@ -34,7 +34,7 @@ static void test_dos_header(void) {
    // Check that the DOS header is skipped
    for (nt_offset = 2; nt_offset < 136; nt_offset += 1) {
       memcpy(header + nt_offset, "PE\0", 4);
-      memcpy(header + 60, &nt_offset, 4);
+      memcpy(header + offsetof(EFI_IMAGE_DOS_HEADER, e_lfanew), &nt_offset, 4);
       // Check that the DOS header is skipped
       if (nt_offset % 8 == 0 && nt_offset >= 64 && nt_offset < 136) {
          assert((void *)extract_pe_header_raw(header, sizeof header) == header + nt_offset);
@@ -46,7 +46,7 @@ static void test_dos_header(void) {
    }
    // Check for integer overflow problems
    for (nt_offset = UINT32_MAX - sizeof header;; nt_offset += 1) {
-      memcpy(header + 60, &nt_offset, 4);
+      memcpy(header + offsetof(EFI_IMAGE_DOS_HEADER, e_lfanew), &nt_offset, 4);
       assert((void *)extract_pe_header_raw(header, sizeof header) == NULL);
       if (nt_offset == UINT32_MAX)
          break;

--- a/test.c
+++ b/test.c
@@ -3,26 +3,32 @@
 #include "winpe.h"
 #include "winpe-private.h"
 
+static const EFI_IMAGE_OPTIONAL_HEADER_UNION*
+extract_pe_header_raw(const void *ptr, size_t size) {
+   return extract_pe_header((struct PeBuffer) {.ptr = ptr, .size = size});
+}
+
+
 // Test DOS header parsing
 static void test_dos_header(void) {
    uint8_t alignas(8) header[sizeof(EFI_IMAGE_OPTIONAL_HEADER_UNION) + 128] = {
       'P', 'E', '\0', '\0',
    };
    // valid
-   assert((void *)extract_pe_header(header, sizeof header - 128) == (void *)header);
+   assert((void *)extract_pe_header_raw(header, sizeof header - 128) == (void *)header);
    // misaligned
-   assert(extract_pe_header(header + 1, sizeof header - 128) == NULL);
+   assert(extract_pe_header_raw(header + 1, sizeof header - 128) == NULL);
    // too short
-   assert(extract_pe_header(header, sizeof header - 129) == NULL);
+   assert(extract_pe_header_raw(header, sizeof header - 129) == NULL);
    // too long
-   assert(extract_pe_header(header, 0x7FFFFFFFUL + 1) == NULL);
+   assert(extract_pe_header_raw(header, 0x7FFFFFFFUL + 1) == NULL);
    // Corrupt the NT header magic
    uint32_t nt_offset = 128;
    memcpy(header + offsetof(EFI_IMAGE_DOS_HEADER, e_lfanew), &nt_offset, 4);
    memcpy(header + nt_offset, "PE\0", 4);
    header[0] = 'M';
-   assert((void *)extract_pe_header(header, sizeof header - 128) == NULL);
-   assert((void *)extract_pe_header(header, sizeof header) == NULL);
+   assert((void *)extract_pe_header_raw(header, sizeof header - 128) == NULL);
+   assert((void *)extract_pe_header_raw(header, sizeof header) == NULL);
    // Add a DOS header
    header[1] = 'Z';
    // Check that the DOS header is skipped
@@ -31,17 +37,17 @@ static void test_dos_header(void) {
       memcpy(header + 60, &nt_offset, 4);
       // Check that the DOS header is skipped
       if (nt_offset % 8 == 0 && nt_offset >= 64 && nt_offset < 136) {
-         assert((void *)extract_pe_header(header, sizeof header) == header + nt_offset);
+         assert((void *)extract_pe_header_raw(header, sizeof header) == header + nt_offset);
          header[nt_offset] = 0;
-         assert((void *)extract_pe_header(header, sizeof header) == NULL);
+         assert((void *)extract_pe_header_raw(header, sizeof header) == NULL);
       } else {
-         assert((void *)extract_pe_header(header, sizeof header) == NULL);
+         assert((void *)extract_pe_header_raw(header, sizeof header) == NULL);
       }
    }
    // Check for integer overflow problems
    for (nt_offset = UINT32_MAX - sizeof header;; nt_offset += 1) {
       memcpy(header + 60, &nt_offset, 4);
-      assert((void *)extract_pe_header(header, sizeof header) == NULL);
+      assert((void *)extract_pe_header_raw(header, sizeof header) == NULL);
       if (nt_offset == UINT32_MAX)
          break;
    }

--- a/winpe-private.h
+++ b/winpe-private.h
@@ -1,4 +1,11 @@
+#include "PeImage.h"
+#include <stdint.h>
+#include <stddef.h>
+
+struct PeBuffer {
+   const uint8_t *ptr;
+   size_t size;
+};
 bool signature_section_check(const uint8_t *const ptr, size_t const len, bool const verbose);
-const EFI_IMAGE_OPTIONAL_HEADER_UNION*
-extract_pe_header(const uint8_t *const ptr, size_t const len);
+const EFI_IMAGE_OPTIONAL_HEADER_UNION* extract_pe_header(const struct PeBuffer b);
 

--- a/winpe.c
+++ b/winpe.c
@@ -34,6 +34,7 @@ static_assert(offsetof(EFI_IMAGE_NT_HEADERS64, FileHeader) == 4,
               "wrong definition of IMAGE_NT_HEADERS64");
 
 #define MIN_FILE_ALIGNMENT (UINT32_C(32))
+#define MAX_FILE_ALIGNMENT (UINT32_C(1) << 16)
 #define MIN_OPTIONAL_HEADER_SIZE (offsetof(EFI_IMAGE_OPTIONAL_HEADER32, DataDirectory))
 #define MAX_OPTIONAL_HEADER_SIZE (sizeof(EFI_IMAGE_OPTIONAL_HEADER64))
 
@@ -251,6 +252,7 @@ validate_image_base_and_alignment(uint64_t const image_base,
           MIN_BASE_ALIGNMENT);
       return false;
    }
+   // Sections must be at least PAGE_SIZE aligned.
    if (section_alignment < MIN_SECTION_ALIGNMENT) {
       LOG("Section alignment too small (0x%" PRIx32 " < 0x%lx)", section_alignment,
           MIN_SECTION_ALIGNMENT);
@@ -264,8 +266,10 @@ validate_image_base_and_alignment(uint64_t const image_base,
       LOG("File alignment too small (0x%" PRIx32 " < 0x%x)", file_alignment, MIN_FILE_ALIGNMENT);
       return false;
    }
-   if (file_alignment > (1U << 16)) {
-      LOG("Too large file alignment (0x%" PRIx32 " > 0x%x)", file_alignment, 1U << 16);
+   // The PE specification limits file alignments to 1 << 16.
+   if (file_alignment > MAX_FILE_ALIGNMENT) {
+      LOG("Too large file alignment (0x%" PRIx32 " > 0x%x)",
+          file_alignment, MAX_FILE_ALIGNMENT);
       return false;
    }
    if (!IS_POW2(file_alignment)) {
@@ -509,6 +513,9 @@ parse_headers(struct PeBuffer full, bool verbose, struct ParsedImage *image, boo
    }
    /* santize number of sections end */
    image->n_sections = untrusted_file_header->NumberOfSections;
+   // No bounds check on untrusted_image_base is needed,
+   // as PE32 images only use a 4-byte field for it.
+   // Therefore, values above max_address simply are not expressable.
    if (!validate_image_base_and_alignment(untrusted_image_base, untrusted_file_alignment,
                                           untrusted_section_alignment))
       return false;
@@ -523,12 +530,15 @@ parse_headers(struct PeBuffer full, bool verbose, struct ParsedImage *image, boo
       return false;
    }
    if (untrusted_pe_header->Pe32.FileHeader.Characteristics & EFI_IMAGE_FILE_RELOCS_STRIPPED) {
-      LOG("Relocations stripped from image");
+      LOG("Relocations stripped from image.  The image can only be loaded at its base address");
       if (strict)
          return false;
    }
    if (untrusted_pe_header->Pe32.FileHeader.Characteristics & EFI_IMAGE_FILE_DLL) {
-      LOG("DLL cannot be executable");
+      LOG("DLLs are not executable directly");
+      // This is a valid PE image, so only reject it in strict mode.
+      if (strict)
+         return false;
    }
    image->file_alignment = untrusted_file_alignment;
    image->section_alignment = untrusted_section_alignment;
@@ -662,11 +672,13 @@ bool pe_parse(const uint8_t *const ptr, size_t const len, struct ParsedImage *im
                         image->sections[i].SizeOfRawData, image->file_alignment);
             return false;
          }
-         /* If the next section starts after the previous one ends, the data in
+         /*
+          * If the next section starts after the previous one ends, the data in
           * between can be tampered with without invalidating the signature.
           * This is bad.  All sections must have size and alignment that
           * are multiple of the file alignment, so it is never necessary to
-          * have alignment padding between sections. */
+          * have alignment padding between sections.
+          */
          if (image->sections[i].PointerToRawData != last_section_start) {
             if (i > 0) {
                LOG_SECTION("starts at 0x%" PRIx32 ", but previous section %.*s ends at 0x%" PRIx32,
@@ -678,8 +690,14 @@ bool pe_parse(const uint8_t *const ptr, size_t const len, struct ParsedImage *im
             }
             return false;
          }
-         /* It is okay for sections to have data beyond their virtual address size (which is ignored),
-          * but not the other way around. */
+         /*
+          * It is okay for sections to have data beyond their virtual
+          * address size (which is ignored), but not the other way around.
+          * VirtualSize specifies the amount of bytes loaded into memory.
+          * All of this data must be read from the section.  If
+          * SizeOfRawData is less than VirtualSize, there is nowhere to
+          * read the last VirtualSize - SizeOfRawData bytes from.
+          */
          if (image->sections[i].SizeOfRawData < image->sections[i].Misc.VirtualSize) {
             LOG_SECTION("has size 0x%" PRIx32 " in the file, but "
                         "0x%" PRIx32 " in memory",
@@ -708,6 +726,9 @@ bool pe_parse(const uint8_t *const ptr, size_t const len, struct ParsedImage *im
                      image->sections[i].VirtualAddress, image->image_base, max_address);
          return false;
       }
+      // Wraparound is impossible: image->image_base is a uint64_t,
+      // image->sections[i].VirtualAddress is bounded by image_address_space,
+      // and image_address_space is bounded by image->max_address - image->image_base.
       uint64_t const untrusted_virtual_address = image->sections[i].VirtualAddress + image->image_base;
       if (max_address - untrusted_virtual_address < image->sections[i].Misc.VirtualSize) {
          LOG_SECTION("has virtual address overflow: 0x%" PRIx64 " + 0x%" PRIx32 " > 0x%" PRIx64,

--- a/winpe.c
+++ b/winpe.c
@@ -228,6 +228,12 @@ get_section_name(const EFI_IMAGE_SECTION_HEADER *section, const struct ParsedIma
              section_name_len);
          return false;
       }
+      // Limit section names to 127 bytes.  No section name should even
+      // come close to this in practice.
+      if (section_name_len > 0x7F) {
+         LOG("Section name exceeds 127 bytes (length %zu)", section_name_len);
+         return false;
+      }
    }
    for (j = 0; j < section_name_len; ++j) {
       if (name[j] == '\0')

--- a/winpe.c
+++ b/winpe.c
@@ -202,6 +202,11 @@ get_section_name(const EFI_IMAGE_SECTION_HEADER *section, const struct ParsedIma
             return false;
          }
       }
+      if (image->string_table == NULL) {
+         LOG("Section name /%s is an index into the string table, but there is no string table",
+             tmpbuf);
+         return false;
+      }
       name = (const uint8_t *)string_table_lookup(image, r);
       if (name == NULL) {
          LOG("String table index %lu is out of bounds for string table", r);

--- a/winpe.c
+++ b/winpe.c
@@ -613,8 +613,9 @@ parse_headers(struct PeBuffer full, bool verbose, struct ParsedImage *image, boo
              untrusted_strings_end, full.size);
          return false;
       }
-      // little-endian, so if the string table is of length 4 (no strings) last
-      // byte will be 0.
+      // Little-endian, so if the string table is of length 4 (no strings) last
+      // byte will be 0.  The addition of string_table_size (which is checked to
+      // be at least sizeof(string_table_size)) means this cannot underflow.
       if (full.ptr[untrusted_strings_end - 1] != 0) {
          LOG("String table not NUL-terminated");
          return false;

--- a/winpe.c
+++ b/winpe.c
@@ -9,6 +9,8 @@
 #include <sys/stat.h>
 #include <err.h>
 #include <unistd.h>
+#include <errno.h>
+#include <limits.h>
 
 #include "winpe.h"
 #include "winpe-private.h"
@@ -152,13 +154,63 @@ extract_pe_header(const struct PeBuffer b)
    return pe_header;
 }
 
-static bool
-validate_section_name(const EFI_IMAGE_SECTION_HEADER *section)
+static const char *
+string_table_lookup(const struct ParsedImage *image, uint64_t offset)
 {
+   if (offset >= image->string_table_size)
+      return NULL;
+   assert(image->string_table);
+   if (offset < 4)
+      return "";
+   return image->string_table + offset;
+}
+
+static const char *
+get_section_name(const EFI_IMAGE_SECTION_HEADER *section, const struct ParsedImage *image, int *len)
+{
+   static_assert(INT_MAX == 0x7FFFFFFFUL, "whoops");
    /* Validate section name */
    const uint8_t *name = section->Name;
    uint32_t j;
-   for (j = 0; j < sizeof(section->Name); ++j) {
+   size_t symbol_len = sizeof(section->Name);
+   *len = 0;
+   bool in_string_table = name[0] == '/';
+   if (in_string_table) {
+      // Copy to ensure NUL termination
+      char tmpbuf[sizeof(section->Name)] = {0};
+      memcpy(tmpbuf, name + 1, sizeof(tmpbuf) - 1);
+      if (tmpbuf[0] < '0' || tmpbuf[0] > '9') {
+         LOG("Invalid string table offset");
+         return false;
+      }
+      char *end;
+      errno = 0;
+      unsigned long r = strtoul(tmpbuf, &end, 10);
+      if (errno != 0) {
+         LOG("Error getting string table offset");
+         return false;
+      }
+      for (const char *p = end; p < tmpbuf + sizeof(tmpbuf) - 1; p++) {
+         if (*p) {
+            LOG("String table index has non-NULL byte after string table "
+                "index");
+            return false;
+         }
+      }
+      name = (const uint8_t *)string_table_lookup(image, r);
+      if (name == NULL) {
+         LOG("String table index %lu is out of bounds for string table", r);
+         return false;
+      }
+      symbol_len = strlen((const char *)name);
+      if (symbol_len <= sizeof(section->Name)) {
+         LOG("Toolchain used string table for symbol of length %zu bytes, but "
+             "symbols of length 8 or less don't need it",
+             symbol_len);
+         return false;
+      }
+   }
+   for (j = 0; j < symbol_len; ++j) {
       if (name[j] == '\0')
          break;
       if (name[j] == '$') {
@@ -180,7 +232,9 @@ validate_section_name(const EFI_IMAGE_SECTION_HEADER *section)
          return false;
       }
    }
-   return true;
+   *len = (int)j;
+   assert(*len > 0 && (size_t)*len == j);
+   return (const char *)name;
 }
 
 #define MAX_IN_MEMORY_ALIGNMENT (1UL << 16)
@@ -443,8 +497,8 @@ parse_headers(struct PeBuffer full, bool verbose, struct ParsedImage *image)
       LOG("No sections!");
       return false;
    }
-   // Wraparound is impossible because nt_header_offset is checked to fit in 2GiB
-   // and header size is bounded by sizeof(EFI_IMAGE_OPTIONAL_HEADER_UNION)
+   // Wraparound is impossible because nt_header_offset is checked to fit in
+   // 2GiB and header size is bounded by sizeof(EFI_IMAGE_OPTIONAL_HEADER_UNION)
    uint32_t section_header_start =
       nt_header_offset + optional_header_size + offsetof(EFI_IMAGE_NT_HEADERS64, OptionalHeader);
 
@@ -480,11 +534,67 @@ parse_headers(struct PeBuffer full, bool verbose, struct ParsedImage *image)
    image->section_alignment = untrusted_section_alignment;
    image->image_base = untrusted_image_base;
    image->characteristics = untrusted_pe_header->Pe32.FileHeader.Characteristics;
+
+   uint32_t untrusted_pointer_to_symbol_table =
+      untrusted_pe_header->Pe32.FileHeader.PointerToSymbolTable;
+   uint32_t untrusted_number_of_symbols = untrusted_pe_header->Pe32.FileHeader.NumberOfSymbols;
+   uint32_t string_table_size;
+
+   if (untrusted_pointer_to_symbol_table == 0) {
+      if (untrusted_number_of_symbols != 0) {
+         LOG("Symbol table nonempty but at offset 0");
+         return false;
+      }
+      image->string_table = NULL;
+      image->string_table_size = 0;
+   } else {
+      if (untrusted_pointer_to_symbol_table < image->size_of_headers) {
+         LOG("Symbol table is at offset 0x%" PRIx32 ", overlapping headers that end at 0x%" PRIx32,
+             untrusted_pointer_to_symbol_table, image->size_of_headers);
+         return false;
+      }
+      // cannot wrap because UINT32_MAX * UINT32_MAX + UINT32_MAX + UINT32_MAX
+      // == UINT64_MAX
+      uint64_t untrusted_strings_start =
+         (uint64_t)untrusted_number_of_symbols * (uint64_t)EFI_IMAGE_SIZEOF_SYMBOL +
+         (uint64_t)untrusted_pointer_to_symbol_table;
+      // cannot wrap because EFI_IMAGE_SIZEOF_SYMBOL is (much) less than
+      // UINT32_MAX
+      if (untrusted_strings_start + sizeof(string_table_size) > full.size) {
+         LOG("Symbol table out of bounds");
+         return false;
+      }
+      memcpy(&string_table_size, full.ptr + untrusted_strings_start, sizeof(string_table_size));
+      if (string_table_size < sizeof(string_table_size)) {
+         LOG("String table too short: min 4, got %" PRIu32, string_table_size);
+         return false;
+      }
+      // cannot wrap because EFI_IMAGE_SIZEOF_SYMBOL is (much) less than
+      // UINT32_MAX
+      uint64_t untrusted_strings_end = untrusted_strings_start + (uint64_t)string_table_size;
+      if (untrusted_strings_end > full.size) {
+         LOG("String table out of bounds: 0x%" PRIx64 " > 0x%zu",
+             untrusted_strings_end, full.size);
+         return false;
+      }
+      // little-endian, so if the string table is of length 4 (no strings) last
+      // byte will be 0.
+      if (full.ptr[untrusted_strings_end - 1] != 0) {
+         LOG("String table not NUL-terminated");
+         return false;
+      }
+      /* string & symbol table sanitize end */
+      image->symbol_table_offset = untrusted_pointer_to_symbol_table;
+      image->string_table_end = untrusted_strings_end;
+      image->string_table = (const char *)full.ptr + untrusted_strings_start;
+      image->string_table_size = string_table_size;
+   }
    return true;
 }
 
 bool pe_parse(const uint8_t *const ptr, size_t const len, struct ParsedImage *image, bool const verbose)
 {
+   memset(image, 0, sizeof(*image));
    const struct PeBuffer full = {.ptr = ptr, .size = len};
    if (!parse_headers(full, verbose, image))
       return false;
@@ -501,7 +611,8 @@ bool pe_parse(const uint8_t *const ptr, size_t const len, struct ParsedImage *im
    uint32_t last_section_start = image->size_of_headers;
    uint64_t last_virtual_address = 0;
    uint64_t last_virtual_address_end = 0;
-   const uint8_t *section_name = NULL, *new_section_name = NULL;
+   const char *last_section_name = NULL;
+   int last_section_name_len = 0;
 
    bool directories_found[EFI_IMAGE_NUMBER_OF_DIRECTORY_ENTRIES] = { 0 };
    for (uint32_t i = 0; i < image->directory_entries; ++i)
@@ -509,37 +620,42 @@ bool pe_parse(const uint8_t *const ptr, size_t const len, struct ParsedImage *im
    directories_found[EFI_IMAGE_DIRECTORY_ENTRY_SECURITY] = true; // special case
 
    for (uint32_t i = 0; i < image->n_sections; ++i) {
+      int section_name_len;
+      const char *section_name = get_section_name(image->sections + i, image, &section_name_len);
+      if (section_name == NULL)
+         return false;
+#define LOG_SECTION(msg, ...)                                                                      \
+   LOG("Section %" PRIu32 " (name %.*s) " msg, i, section_name_len, section_name, ##__VA_ARGS__)
       if (image->sections[i].PointerToRelocations != 0 ||
           image->sections[i].NumberOfRelocations != 0) {
-         LOG("Section %" PRIu32 " contains COFF relocations", i);
+         LOG_SECTION("contains COFF relocations");
          return false;
       }
 
       if (image->sections[i].PointerToLinenumbers != 0 ||
           image->sections[i].NumberOfLinenumbers != 0) {
-         LOG("Section %" PRIu32 " contains COFF line numbers", i);
+         LOG_SECTION("contains COFF line numbers");
          return false;
       }
-
-      if (!validate_section_name(image->sections + i))
-         return false;
-      new_section_name = image->sections[i].Name;
 
       /* Validate PointerToRawData and SizeOfRawData */
       if (image->sections[i].PointerToRawData != 0) {
          if (len - last_section_start < image->sections[i].SizeOfRawData) {
-            LOG("Section %" PRIu32 " too long: length is %" PRIu32 " but only %" PRIu32
-                  " bytes remaining in file", i,
-                  image->sections[i].SizeOfRawData,
-                  (uint32_t)(len - last_section_start));
+            LOG_SECTION("is too long: length is 0x%" PRIx32 " but only 0x%" PRIx32
+                        " bytes remaining in file",
+                        image->sections[i].SizeOfRawData, (uint32_t)(len - last_section_start));
             return false;
          }
          if (!IS_ALIGNED(image->sections[i].PointerToRawData, image->file_alignment)) {
-            LOG("Misaligned raw data pointer");
+            LOG_SECTION("has misaligned raw data pointer: pointer is 0x%" PRIx32
+                        " but alignment is 0x%" PRIx32,
+                        image->sections[i].PointerToRawData, image->file_alignment);
             return false;
          }
          if (!IS_ALIGNED(image->sections[i].SizeOfRawData, image->file_alignment)) {
-            LOG("Misaligned raw data size");
+            LOG_SECTION("has misaligned raw data size: size is 0x%" PRIx32
+                        " but alignment is 0x%" PRIx32,
+                        image->sections[i].SizeOfRawData, image->file_alignment);
             return false;
          }
          /* If the next section starts after the previous one ends, the data in
@@ -548,66 +664,76 @@ bool pe_parse(const uint8_t *const ptr, size_t const len, struct ParsedImage *im
           * are multiple of the file alignment, so it is never necessary to
           * have alignment padding between sections. */
          if (image->sections[i].PointerToRawData != last_section_start) {
-            LOG("Section %" PRIu32 " starts at 0x%" PRIx32 ", but %s at 0x%" PRIx32,
-                i, image->sections[i].PointerToRawData,
-                i > 0 ? "previous section ends" : "NT headers end",
-                last_section_start);
+            if (i > 0) {
+               LOG_SECTION("starts at 0x%" PRIx32 ", but previous section %.*s ends at 0x%" PRIx32,
+                           image->sections[i].PointerToRawData, last_section_name_len,
+                           last_section_name, last_section_start);
+            } else {
+               LOG_SECTION("starts at 0x%" PRIx32 ", but NT headers end at 0x%" PRIx32,
+                           image->sections[i].PointerToRawData, last_section_start);
+            }
             return false;
          }
          /* It is okay for sections to have data beyond their virtual address size (which is ignored),
           * but not the other way around. */
          if (image->sections[i].SizeOfRawData < image->sections[i].Misc.VirtualSize) {
-            LOG("Section %" PRIu32 " (name %.8s) has size 0x%" PRIx32 " in the file, but "
-                "0x%" PRIx32 " in memory", i, new_section_name, image->sections[i].SizeOfRawData,
-                image->sections[i].Misc.VirtualSize);
+            LOG_SECTION("has size 0x%" PRIx32 " in the file, but "
+                        "0x%" PRIx32 " in memory",
+                        image->sections[i].SizeOfRawData, image->sections[i].Misc.VirtualSize);
             return false;
          }
          last_section_start += image->sections[i].SizeOfRawData;
+         if (verbose) {
+            LOG_SECTION("starts at 0x%" PRIx32 " and continues to 0x%" PRIx32,
+                        image->sections[i].PointerToRawData,
+                        last_section_start);
+         }
       } else {
          if (image->sections[i].SizeOfRawData != 0) {
-            LOG("Section %" PRIu32 " starts at zero but has nonzero size", i);
+            LOG_SECTION("starts at zero but has nonzero size");
             return false;
          }
+         if (verbose)
+            LOG_SECTION("has no data on disk");
       }
 
       /* Validate VirtualAddress and VirtualSize */
       if (image->sections[i].VirtualAddress > image_address_space) {
-         LOG("VMA too large: 0x%" PRIx32 " extends beyond address space [0x%" PRIx64 ", 0x%" PRIx64 "]",
-             image->sections[i].VirtualAddress, image->image_base, max_address);
+         LOG_SECTION("has too large VMA: 0x%" PRIx32 " extends beyond address space [0x%" PRIx64
+                     ", 0x%" PRIx64 "]",
+                     image->sections[i].VirtualAddress, image->image_base, max_address);
          return false;
       }
       uint64_t const untrusted_virtual_address = image->sections[i].VirtualAddress + image->image_base;
       if (max_address - untrusted_virtual_address < image->sections[i].Misc.VirtualSize) {
-         LOG("Virtual address overflow: 0x%" PRIx64 " + 0x%" PRIx32 " > 0x%" PRIx64,
-             untrusted_virtual_address, image->sections[i].Misc.VirtualSize, max_address);
+         LOG_SECTION("has virtual address overflow: 0x%" PRIx64 " + 0x%" PRIx32 " > 0x%" PRIx64,
+                     untrusted_virtual_address, image->sections[i].Misc.VirtualSize, max_address);
          return false;
       }
       if (verbose)
-         LOG("Section %" PRIu32 " (name %.8s) has flags 0x%" PRIx32, i, new_section_name, image->sections[i].Characteristics);
+         LOG_SECTION("has flags 0x%" PRIx32, image->sections[i].Characteristics);
       uint32_t untrusted_characteristics = image->sections[i].Characteristics;
       if ((untrusted_characteristics & pe_section_reserved_bits) != 0) {
-         LOG("Section %" PRIu32 ": characteristics 0x%08" PRIx32 " has reserved bits",
-             i, untrusted_characteristics);
+         LOG_SECTION("characteristics 0x%08" PRIx32 " has reserved bits",
+                     untrusted_characteristics);
          return false;
       }
       if ((untrusted_characteristics & EFI_IMAGE_SCN_CNT_INITIALIZED_DATA) &&
           (untrusted_characteristics & EFI_IMAGE_SCN_CNT_UNINITIALIZED_DATA)) {
-         LOG("Section %" PRIu32 "(%.8s) is both initialized and uninitialized data",
-             i, image->sections[i].Name);
+         LOG_SECTION("is both initialized and uninitialized data");
          return false;
       }
       if ((untrusted_characteristics & EFI_IMAGE_SCN_CNT_CODE) &&
           (untrusted_characteristics & EFI_IMAGE_SCN_CNT_UNINITIALIZED_DATA)) {
-         LOG("Section %" PRIu32 "(%.8s) is both code and uninitialized data",
-             i, image->sections[i].Name);
+         LOG_SECTION("is both code and uninitialized data");
          return false;
       }
       if (untrusted_characteristics & EFI_IMAGE_SCN_ALIGN_64BYTES) {
          uint32_t alignment = 1U << (((untrusted_characteristics & EFI_IMAGE_SCN_ALIGN_64BYTES) >> 20) - 1);
          if (!IS_ALIGNED(untrusted_virtual_address, alignment)) {
-            LOG("Section %" PRIu32 " (%.8s) has misaligned VMA for its own alignment: 0x%" PRIx64
-                " not aligned to 0x%" PRIx32,
-                i, image->sections[i].Name, untrusted_virtual_address, alignment);
+            LOG_SECTION("has misaligned VMA for its own alignment: 0x%" PRIx64
+                        " not aligned to 0x%" PRIx32,
+                        untrusted_virtual_address, alignment);
             return false;
          }
       }
@@ -615,29 +741,30 @@ bool pe_parse(const uint8_t *const ptr, size_t const len, struct ParsedImage *im
           (EFI_IMAGE_SCN_CNT_CODE|EFI_IMAGE_SCN_CNT_INITIALIZED_DATA|EFI_IMAGE_SCN_CNT_UNINITIALIZED_DATA)) {
          /* First section in memory must be aligned.  Subsequent ones do not need to be. */
          if (last_virtual_address == 0 && !IS_ALIGNED(untrusted_virtual_address, image->section_alignment)) {
-            LOG("Section %" PRIu32 " (%.8s) has misaligned VMA: 0x%" PRIx64 " not aligned to 0x%" PRIx32,
-                i, image->sections[i].Name, untrusted_virtual_address, image->section_alignment);
+            LOG_SECTION("has misaligned VMA: 0x%" PRIx64 " not aligned to 0x%" PRIx32,
+                        untrusted_virtual_address, image->section_alignment);
             return false;
          }
          if (untrusted_virtual_address < last_virtual_address) {
-            assert(new_section_name != NULL);
-            assert(section_name != NULL);
-            LOG("Sections not sorted by VA: current section (%.8s) VA 0x%" PRIx64 " < previous section (%.8s) 0x%" PRIx64,
-                new_section_name, untrusted_virtual_address, section_name, last_virtual_address);
+            assert(last_section_name != NULL);
+            LOG_SECTION("is not sorted by VA: VA 0x%" PRIx64
+                        " < previous section %.*s VA 0x%" PRIx64,
+                        untrusted_virtual_address, last_section_name_len, last_section_name,
+                        last_virtual_address);
             return false;
          }
          if (untrusted_virtual_address < last_virtual_address_end) {
-            assert(new_section_name != NULL);
-            assert(section_name != NULL);
-            LOG("Sections %.8s (%" PRIu32 ") and %.8s (%" PRIu32 ") overlap in memory: 0x%" PRIx64
-                " in [0x%" PRIx64 ", 0x%" PRIx64 ")",
-                section_name, i - 1, new_section_name, i, untrusted_virtual_address,
-                last_virtual_address, last_virtual_address_end);
+            assert(last_section_name != NULL);
+            LOG_SECTION("overlaps the previous section %.*s: 0x%" PRIx64 " in [0x%" PRIx64
+                        ", 0x%" PRIx64 ")",
+                        last_section_name_len, last_section_name, untrusted_virtual_address,
+                        last_virtual_address, last_virtual_address_end);
             return false;
          }
          last_virtual_address = untrusted_virtual_address;
          last_virtual_address_end = last_virtual_address + image->sections[i].Misc.VirtualSize;
-         section_name = new_section_name;
+         last_section_name = section_name;
+         last_section_name_len = section_name_len;
 
          for (uint32_t j = 0; j < image->directory_entries; ++j) {
             /* Security directory is special. */
@@ -659,20 +786,42 @@ bool pe_parse(const uint8_t *const ptr, size_t const len, struct ParsedImage *im
       }
    }
 
+   if (last_section_start == image->size_of_headers) {
+      LOG("Image has no sections with data");
+      return false;
+   }
+
+   if (image->symbol_table_offset != 0) {
+      if (verbose)
+         LOG("Symbol table starts at offset 0x%" PRIx32, image->symbol_table_offset);
+      if (image->symbol_table_offset < last_section_start) {
+         LOG("Last section ends at offset 0x%" PRIx32
+             ", but symbol table is at offset 0x%" PRIx32
+             " which overlaps headers or sections",
+             last_section_start, image->symbol_table_offset);
+         return false;
+      }
+   }
+
    uint32_t untrusted_signature_size = 0;
    uint32_t untrusted_signature_offset = 0;
    if (image->directory_entries > EFI_IMAGE_DIRECTORY_ENTRY_SECURITY) {
       untrusted_signature_offset = image->directory[EFI_IMAGE_DIRECTORY_ENTRY_SECURITY].VirtualAddress;
       untrusted_signature_size = image->directory[EFI_IMAGE_DIRECTORY_ENTRY_SECURITY].Size;
    }
+   uint32_t string_and_symbol_table_size = image->string_table_end - image->symbol_table_offset;
    if (untrusted_signature_offset == 0) {
-      if (verbose)
+      if (verbose) {
          LOG("File is not signed");
+         if (string_and_symbol_table_size != len - last_section_start)
+            LOG("There are 0x%" PRIx32 " bytes in the string table + symbol table, but 0x%zx bytes after the sections",
+                string_and_symbol_table_size, len - last_section_start);
+      }
    } else {
       /* sanitize signature offset and size start */
       if (untrusted_signature_offset < last_section_start) {
          LOG("Signature overlaps sections (0x%" PRIx32 " < 0x%" PRIx32 ")",
-               untrusted_signature_offset, last_section_start);
+             untrusted_signature_offset, last_section_start);
          return false;
       }
 
@@ -684,7 +833,7 @@ bool pe_parse(const uint8_t *const ptr, size_t const len, struct ParsedImage *im
 
       if (untrusted_signature_offset > len) {
          LOG("Signature starts after end of file (got 0x%" PRIx32 "but only 0x%zu bytes in file)",
-               untrusted_signature_size, len);
+             untrusted_signature_size, len);
          return false;
       }
 
@@ -702,7 +851,14 @@ bool pe_parse(const uint8_t *const ptr, size_t const len, struct ParsedImage *im
       }
       uint32_t signature_len = untrusted_signature_size;
       /* sanitize signature offset and size end */
-
+      if (image->string_table_end > signature_offset) {
+         LOG("String table ends at 0x%" PRIx32 ", but signature starts at 0x%" PRIx32,
+             image->string_table_end, signature_offset);
+         return false;
+      }
+      if (verbose && string_and_symbol_table_size != signature_offset - last_section_start)
+         LOG("There are 0x%" PRIx32 " bytes in the string table + symbol table, but 0x%" PRIx32 " bytes between the last section and the signature",
+             string_and_symbol_table_size, signature_offset - last_section_start);
       if (!signature_section_check(ptr + signature_offset, signature_len, verbose))
           return false;
    }

--- a/winpe.c
+++ b/winpe.c
@@ -165,11 +165,7 @@ validate_section_name(const EFI_IMAGE_SECTION_HEADER *section)
    /* Validate section name */
    const uint8_t *name = section->Name;
    uint32_t j;
-   if (name[0] != '.') {
-      LOG("Section name does not begin with '.'");
-      return false;
-   }
-   for (j = 1; j < sizeof(section->Name); ++j) {
+   for (j = 0; j < sizeof(section->Name); ++j) {
       if (name[j] == '\0')
          break;
       if (name[j] == '$') {

--- a/winpe.c
+++ b/winpe.c
@@ -1,5 +1,4 @@
 #include <stdalign.h>
-#include <stddef.h>
 #include <inttypes.h>
 #include <stdbool.h>
 #include <assert.h>
@@ -35,11 +34,6 @@ static_assert(offsetof(EFI_IMAGE_NT_HEADERS64, FileHeader) == 4,
 #define MIN_FILE_ALIGNMENT (UINT32_C(32))
 #define MIN_OPTIONAL_HEADER_SIZE (offsetof(EFI_IMAGE_OPTIONAL_HEADER32, DataDirectory))
 #define MAX_OPTIONAL_HEADER_SIZE (sizeof(EFI_IMAGE_OPTIONAL_HEADER64))
-
-struct PeBuffer {
-    const uint8_t *ptr;
-    size_t size;
-};
 
 /**
  * Obtain a pointer to size bytes with alignment align at offset offset.
@@ -106,31 +100,30 @@ static_assert(sizeof(struct dos_header) == 64, "header def bug");
  * \return The pointer on success, or NULL on failure.
  */
 const EFI_IMAGE_OPTIONAL_HEADER_UNION*
-extract_pe_header(const uint8_t *const ptr, size_t const len)
+extract_pe_header(const struct PeBuffer b)
 {
-   struct PeBuffer b = { .ptr = ptr, .size = len };
    uint32_t nt_header_offset = 0;
 #define NT_HEADER_OFFSET_LOC ((uint32_t)(offsetof(EFI_IMAGE_DOS_HEADER, e_lfanew)))
    EFI_IMAGE_OPTIONAL_HEADER_UNION const* pe_header;
    static_assert(sizeof(*pe_header) >= sizeof(EFI_IMAGE_DOS_HEADER),
                  "NT header shorter than DOS header?");
 
-   if (len < sizeof(*pe_header)) {
-      LOG("Too short (min length %zu, got %zu)", sizeof(*pe_header), len);
+   if (b.size < sizeof(*pe_header)) {
+      LOG("Too short (min length %zu, got %zu)", sizeof(*pe_header), b.size);
       return NULL;
    }
 
-   if (len > 0x7FFFFFFFUL) {
-      LOG("Too long (max length 0x7FFFFFFF, got 0x%zx)", len);
+   if (b.size > 0x7FFFFFFFUL) {
+      LOG("Too long (max length 0x7FFFFFFF, got 0x%zx)", b.size);
       return NULL;
    }
 
-   if (!ADDRESS_IS_ALIGNED((const void *)ptr, 8)) {
-      LOG("Pointer %p isn't 8-byte aligned", (const void*)ptr);
+   if (!ADDRESS_IS_ALIGNED((const void *)b.ptr, 8)) {
+      LOG("Pointer %p isn't 8-byte aligned", (const void*)b.ptr);
       return NULL;
    }
 
-   if (ptr[0] == 'M' && ptr[1] == 'Z') {
+   if (b.ptr[0] == 'M' && b.ptr[1] == 'Z') {
       const struct dos_header *dos_hdr = STRUCT_AT(&b, 0, struct dos_header);
       if (dos_hdr == NULL) {
          return NULL;
@@ -187,90 +180,6 @@ validate_section_name(const EFI_IMAGE_SECTION_HEADER *section)
          return false;
       }
    }
-   return true;
-}
-
-static bool parse_file_header(const EFI_IMAGE_FILE_HEADER *untrusted_file_header,
-                              uint32_t nt_len,
-                              uint32_t *nt_header_size,
-                              uint32_t *number_of_sections,
-                              uint32_t *optional_header_size)
-{
-   if (!(untrusted_file_header->Characteristics & EFI_IMAGE_FILE_EXECUTABLE_IMAGE)) {
-      LOG("File is not executable");
-      return false;
-   }
-   if (untrusted_file_header->Characteristics & EFI_IMAGE_FILE_RELOCS_STRIPPED) {
-      LOG("Relocations stripped from image");
-      return false;
-   }
-   if (untrusted_file_header->Characteristics & EFI_IMAGE_FILE_DLL) {
-      LOG("DLL cannot be executable");
-      return false;
-   }
-   if (untrusted_file_header->PointerToSymbolTable ||
-       untrusted_file_header->NumberOfSymbols) {
-      LOG("COFF symbol tables detected: symbol table offset 0x%" PRIx32
-          ", number of symbols 0x%" PRIx32,
-          untrusted_file_header->PointerToSymbolTable,
-          untrusted_file_header->NumberOfSymbols);
-      return false;
-   }
-
-   /* sanitize SizeOfOptionalHeader start */
-   uint32_t const SizeOfOptionalHeader = untrusted_file_header->SizeOfOptionalHeader;
-   if (SizeOfOptionalHeader < MIN_OPTIONAL_HEADER_SIZE) {
-      LOG("Optional header too short: got %" PRIu32 " but minimum is %zu",
-          SizeOfOptionalHeader, MIN_OPTIONAL_HEADER_SIZE);
-      return false;
-   }
-   if (SizeOfOptionalHeader > MAX_OPTIONAL_HEADER_SIZE) {
-      LOG("Optional header too long: got %" PRIu32 " but maximum is %zu",
-          SizeOfOptionalHeader, MAX_OPTIONAL_HEADER_SIZE);
-      return false;
-   }
-
-   // This is technically redundant, as parse_optional_header() will
-   // always fail if the optional header size is not a multiple of 8.
-   // Nevertheless, it is included for defense in depth.
-   if (!IS_ALIGNED(SizeOfOptionalHeader, 8)) {
-      LOG("Optional header size 0x%" PRIx16 " not multiple of 8",
-          SizeOfOptionalHeader);
-      return false;
-   }
-
-   /* sanitize NumberOfSections start */
-   uint32_t const NumberOfSections = untrusted_file_header->NumberOfSections;
-   if (NumberOfSections < 1) {
-      LOG("No sections!");
-      return false;
-   }
-
-   if (NumberOfSections > 96) {
-      LOG("Too many sections: got %" PRIu16 ", limit 96", NumberOfSections);
-      return false;
-   }
-
-   /*
-    * Overflow is impossible because NumberOfSections is limited to 96 and
-    * optional_header_size is limited to sizeof(IMAGE_OPTIONAL_HEADER64).
-    * Therefore, the maximum is 40 * 96 + 112 + 16 * 8 = 4080 bytes.
-    */
-   uint32_t const untrusted_nt_headers_size =
-      (NumberOfSections * (uint32_t)sizeof(EFI_IMAGE_SECTION_HEADER)) +
-      (OPTIONAL_HEADER_OFFSET + SizeOfOptionalHeader);
-   /* sanitize NT headers size start */
-   if (nt_len <= untrusted_nt_headers_size) {
-      LOG("Section headers do not fit in image");
-      return false;
-   }
-   *nt_header_size = untrusted_nt_headers_size;
-   *number_of_sections = NumberOfSections;
-   *optional_header_size = SizeOfOptionalHeader;
-   /* sanitize NT headers size end */
-   /* sanitize SizeOfOptionalHeader end */
-   /* sanitize NumberOfSections end */
-
    return true;
 }
 
@@ -348,113 +257,6 @@ validate_data_directories(const EFI_IMAGE_DATA_DIRECTORY *const directory,
    }
 
    return true;
-}
-
-static bool parse_optional_header(EFI_IMAGE_OPTIONAL_HEADER_UNION const *const untrusted_pe_header,
-                                  struct ParsedImage *const image,
-                                  uint32_t len,
-                                  uint32_t nt_header_end,
-                                  uint32_t optional_header_size,
-                                  uint64_t *max_address,
-                                  bool verbose) {
-   uint64_t untrusted_image_base;
-   uint32_t untrusted_file_alignment;
-   uint32_t untrusted_section_alignment;
-   uint32_t untrusted_size_of_headers;
-   uint32_t untrusted_number_of_directory_entries;
-   uint32_t min_size_of_optional_header;
-
-   switch (untrusted_pe_header->Pe32.OptionalHeader.Magic) {
-   case EFI_IMAGE_NT_OPTIONAL_HDR32_MAGIC:
-      if (verbose)
-         LOG("This is a PE32 file: magic 0x10b");
-      // Optional header length checked to be large enough by parse_file_header()
-      static_assert(offsetof(EFI_IMAGE_NT_HEADERS32, OptionalHeader) == 24, "wrong offset");
-      static_assert(offsetof(EFI_IMAGE_OPTIONAL_HEADER32, DataDirectory) == 96, "wrong size");
-      min_size_of_optional_header = offsetof(EFI_IMAGE_OPTIONAL_HEADER32, DataDirectory);
-      untrusted_image_base = untrusted_pe_header->Pe32.OptionalHeader.ImageBase;
-      untrusted_file_alignment = untrusted_pe_header->Pe32.OptionalHeader.FileAlignment;
-      untrusted_section_alignment = untrusted_pe_header->Pe32.OptionalHeader.SectionAlignment;
-      untrusted_size_of_headers = untrusted_pe_header->Pe32.OptionalHeader.SizeOfHeaders;
-      untrusted_number_of_directory_entries = untrusted_pe_header->Pe32.OptionalHeader.NumberOfRvaAndSizes;
-      image->directory = untrusted_pe_header->Pe32.OptionalHeader.DataDirectory;
-      *max_address = UINT32_MAX;
-      break;
-   case EFI_IMAGE_NT_OPTIONAL_HDR64_MAGIC:
-      if (verbose)
-         LOG("This is a PE32+ file: magic 0x20b");
-      if (optional_header_size < offsetof(EFI_IMAGE_OPTIONAL_HEADER64, DataDirectory)) {
-          LOG("Optional header too short for PE32+ file: got %" PRIu32 ", expected at least 112",
-              optional_header_size);
-          return false;
-      }
-      static_assert(offsetof(EFI_IMAGE_NT_HEADERS64, OptionalHeader) == 24, "wrong offset");
-      static_assert(offsetof(EFI_IMAGE_OPTIONAL_HEADER64, DataDirectory) == 112, "wrong size");
-      min_size_of_optional_header = offsetof(EFI_IMAGE_OPTIONAL_HEADER64, DataDirectory);
-      untrusted_image_base = untrusted_pe_header->Pe32Plus.OptionalHeader.ImageBase;
-      untrusted_file_alignment = untrusted_pe_header->Pe32Plus.OptionalHeader.FileAlignment;
-      untrusted_section_alignment = untrusted_pe_header->Pe32Plus.OptionalHeader.SectionAlignment;
-      untrusted_size_of_headers = untrusted_pe_header->Pe32Plus.OptionalHeader.SizeOfHeaders;
-      untrusted_number_of_directory_entries = untrusted_pe_header->Pe32Plus.OptionalHeader.NumberOfRvaAndSizes;
-      image->directory = untrusted_pe_header->Pe32Plus.OptionalHeader.DataDirectory;
-      *max_address = UINT64_MAX;
-      break;
-   case 0xb20:
-   case 0xb10:
-      LOG("Optional header indicates endian-swapped file (not implemented) %" PRIu16,
-          untrusted_pe_header->Pe32.OptionalHeader.Magic);
-      return false;
-   default:
-      LOG("Bad optional header magic %" PRIu16, untrusted_pe_header->Pe32.OptionalHeader.Magic);
-      return false;
-   }
-
-   /* sanitize directory entry number start */
-   if (untrusted_number_of_directory_entries > EFI_IMAGE_NUMBER_OF_DIRECTORY_ENTRIES) {
-      LOG("Too many NumberOfRvaAndSizes (got %" PRIu32 ", limit %d",
-          untrusted_number_of_directory_entries, EFI_IMAGE_NUMBER_OF_DIRECTORY_ENTRIES);
-      return false;
-   }
-
-   uint32_t const expected_optional_header_size =
-      untrusted_number_of_directory_entries * sizeof(EFI_IMAGE_DATA_DIRECTORY) +
-      min_size_of_optional_header;
-   if (optional_header_size != expected_optional_header_size) {
-      LOG("Wrong optional header size: got %" PRIu32 " but computed %" PRIu32,
-          optional_header_size, expected_optional_header_size);
-      return false;
-   }
-   image->directory_entries = untrusted_number_of_directory_entries;
-   /* sanitize directory entry number end */
-
-   if (!validate_image_base_and_alignment(untrusted_image_base,
-                                          untrusted_file_alignment,
-                                          untrusted_section_alignment))
-      return false;
-   image->file_alignment = untrusted_file_alignment;
-   image->section_alignment = untrusted_section_alignment;
-   image->image_base = untrusted_image_base;
-
-   /* sanitize SizeOfHeaders start */
-   if (untrusted_size_of_headers >= len) {
-      LOG("SizeOfHeaders extends past end of image (0x%" PRIx32 " > 0x%" PRIx32 ")",
-          untrusted_size_of_headers, len);
-      return false;
-   }
-   if (!IS_ALIGNED(untrusted_size_of_headers, image->file_alignment)) {
-      LOG("Misaligned size of headers: got 0x%" PRIx32 " but alignment is 0x%" PRIx32,
-          untrusted_size_of_headers, image->file_alignment);
-      return false;
-   }
-   if (untrusted_size_of_headers < nt_header_end) {
-      LOG("Bad size of headers: got 0x%" PRIx32 " but first byte after section headers is 0x%" PRIx32,
-          untrusted_size_of_headers, nt_header_end);
-      return false;
-   }
-   image->size_of_headers = untrusted_size_of_headers;
-   /* sanitize SizeOfHeaders end */
-
-   return validate_data_directories(image->directory, image->directory_entries);
 }
 
 /**
@@ -560,54 +362,142 @@ bool signature_section_check(const uint8_t *const signature, size_t const len, b
    return true;
 }
 
-bool pe_parse(const uint8_t *const ptr, size_t const len, struct ParsedImage *image, bool const verbose)
+static bool
+parse_headers(struct PeBuffer full, bool verbose, struct ParsedImage *image)
 {
-   EFI_IMAGE_OPTIONAL_HEADER_UNION const *const untrusted_pe_header = extract_pe_header(ptr, len);
+
+   uint32_t untrusted_size_of_headers;
+   uint32_t untrusted_data_directory_count;
+   size_t data_directory_offset;
+   uint64_t untrusted_image_base;
+   uint32_t untrusted_file_alignment;
+   uint32_t untrusted_section_alignment;
+
+   EFI_IMAGE_OPTIONAL_HEADER_UNION const *const untrusted_pe_header = extract_pe_header(full);
    if (untrusted_pe_header == NULL) {
       return false;
    }
-   uint32_t const nt_header_offset = (uint32_t)((uint8_t const *)untrusted_pe_header - ptr);
-   const struct PeBuffer remainder = {
-       .ptr = (const uint8_t*)untrusted_pe_header + OPTIONAL_HEADER_OFFSET,
-       .size = (uint32_t)len - (nt_header_offset + OPTIONAL_HEADER_OFFSET),
-   };
+   uint32_t const nt_header_offset = (uint32_t)((uint8_t const *)untrusted_pe_header - full.ptr);
+   const EFI_IMAGE_FILE_HEADER *const untrusted_file_header = &untrusted_pe_header->Pe32.FileHeader;
 
-   uint32_t nt_header_size, optional_header_size;
-   if (!parse_file_header(&untrusted_pe_header->Pe32.FileHeader,
-                          remainder.size,
-                          &nt_header_size,
-                          &image->n_sections,
-                          &optional_header_size)) {
+   switch (untrusted_pe_header->Pe32.OptionalHeader.Magic) {
+   case EFI_IMAGE_NT_OPTIONAL_HDR64_MAGIC:
+      if (verbose)
+         LOG("This is a PE32+ file: magic 0x20b");
+      data_directory_offset = offsetof(EFI_IMAGE_OPTIONAL_HEADER64, DataDirectory);
+      image->directory = untrusted_pe_header->Pe32Plus.OptionalHeader.DataDirectory;
+      untrusted_data_directory_count =
+         untrusted_pe_header->Pe32Plus.OptionalHeader.NumberOfRvaAndSizes;
+      untrusted_file_alignment = untrusted_pe_header->Pe32Plus.OptionalHeader.FileAlignment;
+      untrusted_image_base = untrusted_pe_header->Pe32Plus.OptionalHeader.ImageBase;
+      untrusted_section_alignment = untrusted_pe_header->Pe32Plus.OptionalHeader.SectionAlignment;
+      untrusted_size_of_headers = untrusted_pe_header->Pe32Plus.OptionalHeader.SizeOfHeaders;
+      image->max_address = UINT64_MAX;
+      break;
+   case EFI_IMAGE_NT_OPTIONAL_HDR32_MAGIC:
+      if (verbose)
+         LOG("This is a PE32 file: magic 0x10b");
+      data_directory_offset = offsetof(EFI_IMAGE_OPTIONAL_HEADER32, DataDirectory);
+      image->directory = untrusted_pe_header->Pe32.OptionalHeader.DataDirectory;
+      untrusted_data_directory_count = untrusted_pe_header->Pe32.OptionalHeader.NumberOfRvaAndSizes;
+      untrusted_file_alignment = untrusted_pe_header->Pe32.OptionalHeader.FileAlignment;
+      untrusted_image_base = untrusted_pe_header->Pe32.OptionalHeader.ImageBase;
+      untrusted_section_alignment = untrusted_pe_header->Pe32.OptionalHeader.SectionAlignment;
+      untrusted_size_of_headers = untrusted_pe_header->Pe32.OptionalHeader.SizeOfHeaders;
+      image->max_address = UINT32_MAX;
+      break;
+   default:
+      LOG("Image magic is %" PRIu16 ", which is not valid for 32-bit or 64-bit PE file",
+          untrusted_pe_header->Pe32.OptionalHeader.Magic);
+      return false;
+   }
+   if (untrusted_size_of_headers > full.size) {
+      LOG("Headers do not fit in image: headers %" PRIu32 ", image %zu", untrusted_size_of_headers,
+          full.size);
+      return false;
+   }
+   /* sanitize size of headers end */
+   image->size_of_headers = untrusted_size_of_headers;
+   struct PeBuffer headers = {.ptr = full.ptr, .size = untrusted_size_of_headers};
+
+   if (untrusted_data_directory_count > EFI_IMAGE_NUMBER_OF_DIRECTORY_ENTRIES) {
+      LOG("Image has %" PRIu32 " data directories, but limit is 16",
+          untrusted_data_directory_count);
+      return false;
+   }
+   image->directory_entries = untrusted_data_directory_count;
+   /* sanitize data directory count end */
+
+   /* sanitize size of optional header start */
+   size_t optional_header_size =
+      data_directory_offset + image->directory_entries * sizeof(EFI_IMAGE_DATA_DIRECTORY);
+   if (optional_header_size != untrusted_file_header->SizeOfOptionalHeader) {
+      LOG("Size of optional header is wrong: expected %zu, but got %" PRIu16, optional_header_size,
+          untrusted_file_header->SizeOfOptionalHeader);
+      return false;
+   }
+   /* sanitize size of optional header end */
+
+   /* sanitize number of sections start */
+   if (untrusted_file_header->NumberOfSections < 1) {
+      LOG("No sections!");
+      return false;
+   }
+   // Wraparound is impossible because nt_header_offset is checked to fit in 2GiB
+   // and header size is bounded by sizeof(EFI_IMAGE_OPTIONAL_HEADER_UNION)
+   uint32_t section_header_start =
+      nt_header_offset + optional_header_size + offsetof(EFI_IMAGE_NT_HEADERS64, OptionalHeader);
+
+   image->sections = STRUCT_AT_COUNT(&headers, section_header_start, EFI_IMAGE_SECTION_HEADER,
+                                     untrusted_file_header->NumberOfSections);
+   if (image->sections == NULL) {
+      LOG("Section headers do not fit in headers");
+      return false;
+   }
+   /* santize number of sections end */
+   image->n_sections = untrusted_file_header->NumberOfSections;
+   if (!validate_image_base_and_alignment(untrusted_image_base, untrusted_file_alignment,
+                                          untrusted_section_alignment))
+      return false;
+   if (!IS_ALIGNED(headers.size, untrusted_file_alignment)) {
+      LOG("Misaligned size of headers: got 0x%zu but alignment is 0x%" PRIx32, headers.size,
+          image->file_alignment);
       return false;
    }
 
-   /* Overflow is impossible because nt_header_size is less than len - nt_header_offset. */
-   uint32_t const nt_header_end = nt_header_size + nt_header_offset;
-   uint64_t max_address;
-   if (!parse_optional_header(untrusted_pe_header,
-                              image,
-                              (uint32_t)len,
-                              nt_header_end,
-                              optional_header_size,
-                              &max_address,
-                              verbose)) {
+   if (!(untrusted_pe_header->Pe32.FileHeader.Characteristics & EFI_IMAGE_FILE_EXECUTABLE_IMAGE)) {
+      LOG("File is not executable");
       return false;
    }
-   image->sections = STRUCT_AT_COUNT(&remainder, optional_header_size, EFI_IMAGE_SECTION_HEADER, image->n_sections);
-   assert(image->sections);
-   for (uint32_t i = nt_header_end; i < image->size_of_headers; ++i) {
-      if (ptr[i]) {
-         LOG("Non-zero byte at offset 0x%" PRIx32 " that should be zero", i);
-         return false;
-      }
+   if (untrusted_pe_header->Pe32.FileHeader.Characteristics & EFI_IMAGE_FILE_RELOCS_STRIPPED) {
+      LOG("Relocations stripped from image");
+      return false;
    }
+   if (untrusted_pe_header->Pe32.FileHeader.Characteristics & EFI_IMAGE_FILE_DLL) {
+      LOG("DLL cannot be executable");
+   }
+   image->file_alignment = untrusted_file_alignment;
+   image->section_alignment = untrusted_section_alignment;
+   image->image_base = untrusted_image_base;
+   image->characteristics = untrusted_pe_header->Pe32.FileHeader.Characteristics;
+   return true;
+}
+
+bool pe_parse(const uint8_t *const ptr, size_t const len, struct ParsedImage *image, bool const verbose)
+{
+   const struct PeBuffer full = {.ptr = ptr, .size = len};
+   if (!parse_headers(full, verbose, image))
+      return false;
+
+   if (!validate_data_directories(image->directory, image->directory_entries))
+      return false;
 
    /* Overflow is impossible: max_address is always at least as large as image->image_base */
-   uint64_t image_address_space = max_address - image->image_base;
+   uint64_t image_address_space = image->max_address - image->image_base;
    if (image_address_space > UINT32_MAX)
       image_address_space = UINT32_MAX;
    image_address_space &= ~(uint64_t)(image->section_alignment - 1);
-   max_address = image->image_base + image_address_space;
+   uint64_t const max_address = image->image_base + image_address_space;
    uint32_t last_section_start = image->size_of_headers;
    uint64_t last_virtual_address = 0;
    uint64_t last_virtual_address_end = 0;

--- a/winpe.c
+++ b/winpe.c
@@ -251,10 +251,12 @@ get_section_name(const EFI_IMAGE_SECTION_HEADER *section, const struct ParsedIma
          return false;
       }
    }
-   for (uint8_t k = j; k < sizeof(section->Name); ++k) {
-      if (name[k] != '\0') {
-         LOG("Section name has non-NUL byte after NUL byte");
-         return false;
+   if (!in_string_table) {
+      for (uint8_t k = j; k < sizeof(section->Name); ++k) {
+         if (name[k] != '\0') {
+            LOG("Section name has non-NUL byte after NUL byte");
+            return false;
+         }
       }
    }
    *len = (int)j;

--- a/winpe.c
+++ b/winpe.c
@@ -173,7 +173,7 @@ get_section_name(const EFI_IMAGE_SECTION_HEADER *section, const struct ParsedIma
    /* Validate section name */
    const uint8_t *name = section->Name;
    uint32_t j;
-   size_t symbol_len = sizeof(section->Name);
+   size_t section_name_len = sizeof(section->Name);
    *len = 0;
    bool in_string_table = name[0] == '/';
    if (in_string_table) {
@@ -203,15 +203,15 @@ get_section_name(const EFI_IMAGE_SECTION_HEADER *section, const struct ParsedIma
          LOG("String table index %lu is out of bounds for string table", r);
          return false;
       }
-      symbol_len = strlen((const char *)name);
-      if (symbol_len <= sizeof(section->Name)) {
-         LOG("Toolchain used string table for symbol of length %zu bytes, but "
-             "symbols of length 8 or less don't need it",
-             symbol_len);
+      section_name_len = strlen((const char *)name);
+      if (section_name_len <= sizeof(section->Name)) {
+         LOG("Toolchain used string table for section name of length %zu "
+             "bytes, but section names of length 8 or less don't need it",
+             section_name_len);
          return false;
       }
    }
-   for (j = 0; j < symbol_len; ++j) {
+   for (j = 0; j < section_name_len; ++j) {
       if (name[j] == '\0')
          break;
       if (name[j] == '$') {

--- a/winpe.c
+++ b/winpe.c
@@ -207,6 +207,15 @@ get_section_name(const EFI_IMAGE_SECTION_HEADER *section, const struct ParsedIma
              tmpbuf);
          return false;
       }
+      // This is technically possible, but it would take a completely silly
+      // compiler or linker to produce this, and it could easily confuse tools.
+      // Example: a tool copies the string table without its length, and
+      // subtracts 4 from the offset to get the offset into the string table.
+      // This then wraps around or underflows, resulting in out-of-bounds access.
+      if (r < 4L) {
+         LOG("String table index %lu points into string table length", r);
+         return false;
+      }
       name = (const uint8_t *)string_table_lookup(image, r);
       if (name == NULL) {
          LOG("String table index %lu is out of bounds for string table", r);

--- a/winpe.c
+++ b/winpe.c
@@ -184,6 +184,10 @@ get_section_name(const EFI_IMAGE_SECTION_HEADER *section, const struct ParsedIma
          LOG("Invalid string table offset");
          return false;
       }
+      if (tmpbuf[0] == '0' && tmpbuf[1] != '\0') {
+         LOG("Spurious leading zero in string table offset");
+         return false;
+      }
       char *end;
       errno = 0;
       unsigned long r = strtoul(tmpbuf, &end, 10);

--- a/winpe.c
+++ b/winpe.c
@@ -417,9 +417,8 @@ bool signature_section_check(const uint8_t *const signature, size_t const len, b
 }
 
 static bool
-parse_headers(struct PeBuffer full, bool verbose, struct ParsedImage *image)
+parse_headers(struct PeBuffer full, bool verbose, struct ParsedImage *image, bool strict)
 {
-
    uint32_t untrusted_size_of_headers;
    uint32_t untrusted_data_directory_count;
    size_t data_directory_offset;
@@ -525,7 +524,8 @@ parse_headers(struct PeBuffer full, bool verbose, struct ParsedImage *image)
    }
    if (untrusted_pe_header->Pe32.FileHeader.Characteristics & EFI_IMAGE_FILE_RELOCS_STRIPPED) {
       LOG("Relocations stripped from image");
-      return false;
+      if (strict)
+         return false;
    }
    if (untrusted_pe_header->Pe32.FileHeader.Characteristics & EFI_IMAGE_FILE_DLL) {
       LOG("DLL cannot be executable");
@@ -592,11 +592,12 @@ parse_headers(struct PeBuffer full, bool verbose, struct ParsedImage *image)
    return true;
 }
 
-bool pe_parse(const uint8_t *const ptr, size_t const len, struct ParsedImage *image, bool const verbose)
+bool pe_parse(const uint8_t *const ptr, size_t const len, struct ParsedImage *image,
+              bool const verbose, bool const strict, bool const require_relocs)
 {
    memset(image, 0, sizeof(*image));
    const struct PeBuffer full = {.ptr = ptr, .size = len};
-   if (!parse_headers(full, verbose, image))
+   if (!parse_headers(full, verbose, image, strict))
       return false;
 
    if (!validate_data_directories(image->directory, image->directory_entries))
@@ -621,6 +622,7 @@ bool pe_parse(const uint8_t *const ptr, size_t const len, struct ParsedImage *im
 
    for (uint32_t i = 0; i < image->n_sections; ++i) {
       int section_name_len;
+      // This is not NUL-terminated if section_name_len is 8.
       const char *section_name = get_section_name(image->sections + i, image, &section_name_len);
       if (section_name == NULL)
          return false;
@@ -629,13 +631,15 @@ bool pe_parse(const uint8_t *const ptr, size_t const len, struct ParsedImage *im
       if (image->sections[i].PointerToRelocations != 0 ||
           image->sections[i].NumberOfRelocations != 0) {
          LOG_SECTION("contains COFF relocations");
-         return false;
+         if (strict)
+            return false;
       }
 
       if (image->sections[i].PointerToLinenumbers != 0 ||
           image->sections[i].NumberOfLinenumbers != 0) {
          LOG_SECTION("contains COFF line numbers");
-         return false;
+         if (strict)
+            return false;
       }
 
       /* Validate PointerToRawData and SizeOfRawData */
@@ -716,17 +720,54 @@ bool pe_parse(const uint8_t *const ptr, size_t const len, struct ParsedImage *im
       if ((untrusted_characteristics & pe_section_reserved_bits) != 0) {
          LOG_SECTION("characteristics 0x%08" PRIx32 " has reserved bits",
                      untrusted_characteristics);
-         return false;
+         if (strict)
+            return false;
       }
-      if ((untrusted_characteristics & EFI_IMAGE_SCN_CNT_INITIALIZED_DATA) &&
-          (untrusted_characteristics & EFI_IMAGE_SCN_CNT_UNINITIALIZED_DATA)) {
-         LOG_SECTION("is both initialized and uninitialized data");
-         return false;
-      }
-      if ((untrusted_characteristics & EFI_IMAGE_SCN_CNT_CODE) &&
-          (untrusted_characteristics & EFI_IMAGE_SCN_CNT_UNINITIALIZED_DATA)) {
-         LOG_SECTION("is both code and uninitialized data");
-         return false;
+      if (untrusted_characteristics & EFI_IMAGE_SCN_CNT_CODE) {
+         if (verbose)
+            LOG_SECTION("is executable code");
+         if (!(untrusted_characteristics & EFI_IMAGE_SCN_MEM_EXECUTE)) {
+            LOG_SECTION("is code but has no execute permissions");
+            if (strict)
+               return false;
+         }
+         if (untrusted_characteristics & EFI_IMAGE_SCN_MEM_WRITE) {
+            LOG_SECTION("is code but has write permissions");
+            if (strict)
+               return false;
+         }
+         if (untrusted_characteristics & EFI_IMAGE_SCN_CNT_UNINITIALIZED_DATA) {
+            LOG_SECTION("is both code and uninitialized data");
+            return false;
+         }
+         if (untrusted_characteristics & EFI_IMAGE_SCN_CNT_INITIALIZED_DATA) {
+            LOG_SECTION("is both code and initialized data");
+            if (strict)
+               return false;
+         }
+      } else {
+         if (untrusted_characteristics & EFI_IMAGE_SCN_CNT_INITIALIZED_DATA) {
+            if (verbose)
+               LOG_SECTION("is initialized data");
+            if (untrusted_characteristics & EFI_IMAGE_SCN_CNT_UNINITIALIZED_DATA) {
+               LOG_SECTION("is both initialized and uninitialized data");
+               if (strict)
+                  return false;
+            }
+         } else {
+            if (verbose) {
+               if (untrusted_characteristics & EFI_IMAGE_SCN_CNT_UNINITIALIZED_DATA) {
+                  LOG_SECTION("is uninitialized data");
+               } else {
+                  LOG_SECTION("is not code, initialized data, or uninitialized data");
+               }
+            }
+         }
+         if (untrusted_characteristics & EFI_IMAGE_SCN_MEM_EXECUTE) {
+            LOG_SECTION("is data but has execute permissions");
+            if (strict)
+               return false;
+         }
       }
       if (untrusted_characteristics & EFI_IMAGE_SCN_ALIGN_64BYTES) {
          uint32_t alignment = 1U << (((untrusted_characteristics & EFI_IMAGE_SCN_ALIGN_64BYTES) >> 20) - 1);
@@ -736,6 +777,25 @@ bool pe_parse(const uint8_t *const ptr, size_t const len, struct ParsedImage *im
                         untrusted_virtual_address, alignment);
             return false;
          }
+      }
+      if (untrusted_characteristics & EFI_IMAGE_SCN_MEM_DISCARDABLE) {
+         if (section_name_len != (int)sizeof(".reloc") - 1 ||
+             memcmp(section_name, ".reloc", sizeof(".reloc")) != 0) {
+            LOG_SECTION("is discardable, which isn't expected");
+            if (strict)
+               return false;
+         } else {
+            if (require_relocs) {
+               LOG_SECTION("is discardable, causing crashes with some bootloaders");
+               return false;
+            }
+         }
+      }
+      if ((untrusted_characteristics & (EFI_IMAGE_SCN_MEM_EXECUTE|EFI_IMAGE_SCN_MEM_WRITE)) ==
+          (EFI_IMAGE_SCN_MEM_EXECUTE|EFI_IMAGE_SCN_MEM_WRITE)) {
+         LOG_SECTION("is both writeable and executable");
+         if (strict)
+            return false;
       }
       if (untrusted_characteristics &
           (EFI_IMAGE_SCN_CNT_CODE|EFI_IMAGE_SCN_CNT_INITIALIZED_DATA|EFI_IMAGE_SCN_CNT_UNINITIALIZED_DATA)) {
@@ -849,6 +909,7 @@ bool pe_parse(const uint8_t *const ptr, size_t const len, struct ParsedImage *im
          LOG("0x%zx bytes of junk after signature", len - (untrusted_signature_size + signature_offset));
          return false;
       }
+
       uint32_t signature_len = untrusted_signature_size;
       /* sanitize signature offset and size end */
       if (image->string_table_end > signature_offset) {

--- a/winpe.h
+++ b/winpe.h
@@ -21,6 +21,7 @@ typedef char16_t CHAR16;
 #include "PeImage.h"
 
 struct ParsedImage {
+   uint64_t max_address;
    uint64_t image_base;
    uint32_t file_alignment;
    uint32_t section_alignment;
@@ -29,7 +30,7 @@ struct ParsedImage {
    uint32_t directory_entries;
    uint32_t n_sections;
    uint32_t size_of_headers;
-   uint32_t _pad0;
+   uint32_t characteristics;
 };
 
 enum {

--- a/winpe.h
+++ b/winpe.h
@@ -31,6 +31,9 @@ struct ParsedImage {
    uint32_t n_sections;
    uint32_t size_of_headers;
    uint32_t characteristics;
+   const char *string_table;
+   size_t string_table_size;
+   uint32_t symbol_table_offset, string_table_end;
 };
 
 enum {

--- a/winpe.h
+++ b/winpe.h
@@ -39,8 +39,8 @@ struct ParsedImage {
 enum {
     pe_section_reserved_bits = 0xF6D1F,
 };
-
-bool pe_parse(const uint8_t *const ptr, size_t const len, struct ParsedImage *image, bool verbose);
+bool pe_parse(const uint8_t *const ptr, size_t const len, struct ParsedImage *image,
+              bool const verbose, bool const strict, bool const require_relocs);
 
 #define LOG(a, ...) (fprintf(stderr, a "\n", ## __VA_ARGS__))
 


### PR DESCRIPTION
Previously, pecheck wrongly rejected valid `xen.efi` binaries, and even rejected Fedora’s GRUB.  This makes both pass.  GRUB passes with `--strict`, but Fedora’s `xen.efi` fails with `--strict` because of a writeable and executable section.  Also, there is a `--require-relocs` flag to ensure that the `.reloc` section is not discarded by some bootloaders.  This causes Xen to crash when such a bootloader is used.